### PR TITLE
Fix gcc warning related to 'char' comparison

### DIFF
--- a/base64.c
+++ b/base64.c
@@ -131,7 +131,7 @@ base64_decode(const char *in, unsigned int inlen, unsigned char *out)
 		if (in[i] == BASE64_PAD) {
 			break;
 		}
-		if (in[i] < 0) {
+		if ((in[i] & 0x80) != 0) {
 			return 0;
 		}
 

--- a/base64.c
+++ b/base64.c
@@ -3,6 +3,8 @@
 #include "base64.h"
 
 #define BASE64_PAD '='
+#define BASE64DE_FIRST '+'
+#define BASE64DE_LAST 'z'
 
 /* BASE 64 encode table */
 static const char base64en[] = {
@@ -131,7 +133,7 @@ base64_decode(const char *in, unsigned int inlen, unsigned char *out)
 		if (in[i] == BASE64_PAD) {
 			break;
 		}
-		if ((in[i] & 0x80) != 0) {
+		if (in[i] < BASE64DE_FIRST || in[i] > BASE64DE_LAST) {
 			return 0;
 		}
 


### PR DESCRIPTION
'char' is unsigned in some architectures, generating a warning
when tested for negative values.

Warning from gcc (ppc):
"comparison is always false due to limited range of data type".